### PR TITLE
Add planned RTL aux function

### DIFF
--- a/ArduPlane/RC_Channel_Plane.cpp
+++ b/ArduPlane/RC_Channel_Plane.cpp
@@ -148,6 +148,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
     case AUX_FUNC::LOITER:
     case AUX_FUNC::MANUAL:
     case AUX_FUNC::RTL:
+    case AUX_FUNC::PLANNED_RTL:
     case AUX_FUNC::TAKEOFF:
     case AUX_FUNC::FBWA:
     case AUX_FUNC::AIRBRAKE:
@@ -266,6 +267,10 @@ bool RC_Channel_Plane::do_aux_function(const AuxFuncTrigger &trigger)
 
     case AUX_FUNC::RTL:
         do_aux_function_change_mode(Mode::Number::RTL, ch_flag);
+        break;
+
+    case AUX_FUNC::PLANNED_RTL:
+        do_aux_function_change_mode(Mode::Number::PLANNED_RTL, ch_flag);
         break;
 
     case AUX_FUNC::TAKEOFF:

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -260,7 +260,8 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane, Sub}: 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw
     // @Values{Copter, Rover, Plane, Blimp, Sub}:  218:Loweheiser throttle
     // @Values{Copter}: 219:Transmitter Tuning
-    // @Values{All-Vehicles}: 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8, 308:Scripting9, 309:Scripting10, 310:Scripting11, 311:Scripting12, 312:Scripting13, 313:Scripting14, 314:Scripting15, 315:Scripting16
+    // @Values{Copter, Plane}: 221:Planned RTL Mode
+    // @Values{Copter, Rover, Plane, Sub}: 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8, 308:Scripting9, 309:Scripting10, 310:Scripting11, 311:Scripting12, 312:Scripting13, 313:Scripting14, 314:Scripting15, 315:Scripting16
     // @Values{All-Vehicles}: 316:Stop-Restart Scripting
     // @User: Standard
     AP_GROUPINFO("OPTION",  6, RC_Channel, option, 0),

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -394,6 +394,7 @@ public:
         TRANSMITTER_TUNING = 219, // use a transmitter knob or slider for in-flight tuning
         TRANSMITTER_TUNING2 = 220, // use another transmitter knob or slider for in-flight tuning
 #endif  // AP_RC_TRANSMITTER_TUNING_ENABLED
+        PLANNED_RTL = 221, // Compute a planned RTL path home
 
         // inputs 248-249 are reserved for the Skybrush fork at
         // https://github.com/skybrush-io/ardupilot


### PR DESCRIPTION
# Tests Performed 

Start SITL
```
./Tools/autotest/sim_vehicle.py -v plane --map --console
```

Configure AUX function on channel 8
```
param set RC8_OPTION 221
```


Disable
```
long DO_AUX_FUNCTION 221 0
```

Enable
```
long DO_AUX_FUNCTION 221 2
```


<img width="502" height="361" alt="image" src="https://github.com/user-attachments/assets/58014e71-1dff-4469-aa3d-627918ba1492" />
